### PR TITLE
General improvements

### DIFF
--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -18,6 +18,15 @@ struct AllComponentsView: View {
                     ScreenTitle("Screen Title")
                     SectionTitle("Section Title")
                     ItemTitle("Item Title")
+                    ItemTitle(
+                        NSAttributedString(
+                            string: "Attributed Text",
+                            attributes: [
+                                .underlineStyle: 1,
+                                .foregroundColor: Color.blue
+                            ]
+                        )
+                    )
                 }
 
                 ThemedDivider()
@@ -33,7 +42,7 @@ struct AllComponentsView: View {
                     PrimaryButton("Primary Button") { }
                     SecondaryButton("Secondary Button") { }
                     BorderlessButton("Borderless Button") { }
-                    InactiveButton("Inactive Button") { }
+                    InactiveButton("Inactive Button")
                     DestructiveButton("Destructive Button") { }
                 }
 

--- a/Sources/NiceComponents/Button/InactiveButton.swift
+++ b/Sources/NiceComponents/Button/InactiveButton.swift
@@ -10,21 +10,20 @@ import SwiftUI
 public struct InactiveButton: View {
     let text: String
     let style: ButtonStyle
-    let onClick: () -> Void
 
-    public init(_ text: String, style: ButtonStyle? = nil, onClick: @escaping () -> Void) {
+    public init(_ text: String, style: ButtonStyle? = nil) {
         self.text = text
         self.style = style ?? Config.current.inactiveButtonStyle
-        self.onClick = onClick
     }
 
     public var body: some View {
-        Button(action: onClick) {
+        Button(action: {}) {
             Text(text)
                 .foregroundColor(style.onSurfaceColor)
                 .scaledFont(name: style.textStyle.name, size: style.textStyle.size, weight: style.textStyle.weight)
                 .frame(maxWidth: .infinity, minHeight: style.height, maxHeight: style.height)
         }
+        .disabled(true)
         .fixedSize(horizontal: false, vertical: true)
         .background(style.surfaceColor)
         .cornerRadius(style.border.radius)

--- a/Sources/NiceComponents/Components/ResizableImage.swift
+++ b/Sources/NiceComponents/Components/ResizableImage.swift
@@ -9,22 +9,46 @@ import SwiftUI
 import UIKit
 import Kingfisher
 
-public struct ResizableImage: View {
+struct ResizableImage: View {
+    let bundleString: String?
     let url: URL?
-    let width: CGFloat?
-    let height: CGFloat?
+    let width: CGFloat
+    let height: CGFloat
+    let tintColor: Color?
 
-    public init(_ url: URL?, width: CGFloat? = nil, height: CGFloat? = nil) {
-        self.url = url
-        self.width = width
+    init(_ bundleString: String, width: CGFloat, height: CGFloat, tintColor: Color? = nil) {
+        self.bundleString = bundleString
+        self.url = nil
         self.height = height
+        self.width = width
+        self.tintColor = tintColor
     }
 
-    public var body: some View {
-        KFImage(url)
-            .resizable()
-            .scaledToFill()
-            .frame(width: width, height: height)
-            .clipped()
+    init(_ url: URL?, width: CGFloat, height: CGFloat) {
+        self.bundleString = nil
+        self.url = url
+        self.height = height
+        self.width = width
+        self.tintColor = nil
+    }
+
+    var body: some View {
+        if let url = url {
+            KFImage(url)
+                .resizable()
+                .scaledToFill()
+                .frame(width: width, height: height)
+                .clipped()
+        } else if let string = bundleString {
+            Image(string)
+                .renderingMode(tintColor == nil ? .original : .template)
+                .resizable()
+                .foregroundColor(tintColor)
+                .scaledToFill()
+                .frame(width: width, height: height)
+                .clipped()
+        } else {
+            EmptyView()
+        }
     }
 }

--- a/Sources/NiceComponents/Helper/ContentLoadState.swift
+++ b/Sources/NiceComponents/Helper/ContentLoadState.swift
@@ -7,9 +7,25 @@
 
 import Foundation
 
-public enum ContentLoadState {
+public enum ContentLoadState: Equatable {
     case loading
     case noData
     case hasData
     case error(error: Error)
+
+    public static func == (lhs: ContentLoadState, rhs: ContentLoadState) -> Bool {
+        switch lhs {
+        case .loading:
+            if case .loading = rhs { return true }
+        case .noData:
+            if case .noData = rhs { return true }
+        case .hasData:
+            if case .hasData = rhs { return true }
+        case .error(let error):
+            if case .error(let rhsError) = rhs {
+                return error.localizedDescription == rhsError.localizedDescription
+            }
+        }
+        return false
+    }
 }

--- a/Sources/NiceComponents/Helper/Text+AttributedString.swift
+++ b/Sources/NiceComponents/Helper/Text+AttributedString.swift
@@ -1,0 +1,62 @@
+//
+//  Text+AttributedString.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-06-08.
+//
+
+import SwiftUI
+
+extension Text {
+    init(_ astring: NSAttributedString) {
+        self.init("")
+
+        astring.enumerateAttributes(in: NSRange(location: 0, length: astring.length), options: []) { attrs, range, _  in
+
+            var text = Text(astring.attributedSubstring(from: range).string)
+
+            if let color = attrs[NSAttributedString.Key.foregroundColor] as? Color {
+                text = text.foregroundColor(color)
+            }
+
+            if let color = attrs[NSAttributedString.Key.foregroundColor] as? UIColor {
+                text = text.foregroundColor(Color(color))
+            }
+
+            if let font = attrs[NSAttributedString.Key.font] as? Font {
+                text = text.font(font)
+            }
+
+            if let font = attrs[NSAttributedString.Key.font] as? UIFont {
+                text = text.font(.init(font))
+            }
+
+            if let kern = attrs[NSAttributedString.Key.kern] as? CGFloat {
+                text = text.kerning(kern)
+            }
+
+            if let striked = attrs[NSAttributedString.Key.strikethroughStyle] as? NSNumber, striked != 0 {
+                if let strikeColor = (attrs[NSAttributedString.Key.strikethroughColor] as? UIColor) {
+                    text = text.strikethrough(true, color: Color(strikeColor))
+                } else {
+                    text = text.strikethrough(true)
+                }
+            }
+
+            if let baseline = attrs[NSAttributedString.Key.baselineOffset] as? NSNumber {
+                text = text.baselineOffset(CGFloat(baseline.floatValue))
+            }
+
+            if let underline = attrs[NSAttributedString.Key.underlineStyle] as? NSNumber, underline != 0 {
+                if let underlineColor = (attrs[NSAttributedString.Key.underlineColor] as? UIColor) {
+                    text = text.underline(true, color: Color(underlineColor))
+                } else {
+                    text = text.underline(true)
+                }
+            }
+            // swiftlint:disable shorthand_operator
+            self = self + text
+
+        }
+    }
+}

--- a/Sources/NiceComponents/Modifiers/ShadowModifier.swift
+++ b/Sources/NiceComponents/Modifiers/ShadowModifier.swift
@@ -1,0 +1,31 @@
+//
+//  ShadowModifier.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-06-09.
+//
+
+import SwiftUI
+
+public struct ShadowStyle {
+    public let color: Color
+    public let radius: CGFloat
+    public let x: CGFloat
+    public let y: CGFloat
+}
+
+struct ShadowModifier: ViewModifier {
+
+    let style: ShadowStyle
+
+    func body(content: Content) -> some View {
+        content
+            .shadow(color: style.color, radius: style.radius, x: style.x, y: style.y)
+    }
+}
+
+public extension View {
+    func shadow(_ style: ShadowStyle = Config.current.shadowStyle) -> some View {
+        modifier(ShadowModifier(style: style))
+    }
+}

--- a/Sources/NiceComponents/Text/BodyText.swift
+++ b/Sources/NiceComponents/Text/BodyText.swift
@@ -7,13 +7,17 @@
 
 import SwiftUI
 
-public struct BodyText: View {
-    public let text: String
+public struct BodyText: NiceText {
+    public let text: NSAttributedString
     public let style: TypeStyle
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public static var defaultStyle: TypeStyle {
+        Config.current.bodyTextStyle
+    }
+
+    public init(_ text: NSAttributedString, style: TypeStyle? = nil) {
         self.text = text
-        self.style = style ?? Config.current.bodyTextStyle
+        self.style = style ?? Self.defaultStyle
     }
 
     public var body: some View {

--- a/Sources/NiceComponents/Text/DetailText.swift
+++ b/Sources/NiceComponents/Text/DetailText.swift
@@ -7,13 +7,17 @@
 
 import SwiftUI
 
-public struct DetailText: View {
-    public let text: String
+public struct DetailText: NiceText {
+    public let text: NSAttributedString
     public let style: TypeStyle
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public static var defaultStyle: TypeStyle {
+        Config.current.detailTextStyle
+    }
+
+    public init(_ text: NSAttributedString, style: TypeStyle? = nil) {
         self.text = text
-        self.style = style ?? Config.current.detailTextStyle
+        self.style = style ?? Self.defaultStyle
     }
 
     public var body: some View {

--- a/Sources/NiceComponents/Theme/ColorTheme.swift
+++ b/Sources/NiceComponents/Theme/ColorTheme.swift
@@ -25,6 +25,8 @@ public struct ColorTheme {
     public var surface: Color
     public var onSurface: Color
 
+    public var shadow: Color
+
     public init(primary: Color? = nil,
             primaryVariant: Color? = nil,
             onPrimary: Color? = nil,
@@ -36,7 +38,8 @@ public struct ColorTheme {
             error: Color? = nil,
             onError: Color? = nil,
             surface: Color? = nil,
-            onSurface: Color? = nil) {
+            onSurface: Color? = nil,
+            shadow: Color? = nil) {
         self.primary = primary ?? Color("primary", bundle: Bundle.module)
         self.primaryVariant = primaryVariant ?? Color("primaryVariant", bundle: Bundle.module)
         self.onPrimary = onPrimary ?? Color("onPrimary", bundle: Bundle.module)
@@ -53,5 +56,7 @@ public struct ColorTheme {
 
         self.surface = surface ?? Color("surface", bundle: Bundle.module)
         self.onSurface = onSurface ?? Color("onSurface", bundle: Bundle.module)
+
+        self.shadow = shadow ?? Color.black.opacity(0.25)
     }
 }

--- a/Sources/NiceComponents/Theme/Config.swift
+++ b/Sources/NiceComponents/Theme/Config.swift
@@ -49,6 +49,8 @@ public struct Config {
     public var screenTitleStyle: TypeStyle
     public var sectionTitleStyle: TypeStyle
 
+    public var shadowStyle: ShadowStyle
+
     public init(colorTheme: ColorTheme? = nil, typeTheme: TypeTheme? = nil) {
         self.colorTheme = colorTheme ?? ColorTheme()
         self.typeTheme = typeTheme ?? TypeTheme()
@@ -113,6 +115,15 @@ public struct Config {
         sectionTitleStyle = TypeStyle(
             color: self.colorTheme.onSurface,
             theme: self.typeTheme.headline2
+        )
+
+        // Set Shadow style
+
+        shadowStyle = ShadowStyle(
+            color: self.colorTheme.shadow,
+            radius: 10.0,
+            x: 0,
+            y: 3
         )
     }
 

--- a/Sources/NiceComponents/Theme/Layout.swift
+++ b/Sources/NiceComponents/Theme/Layout.swift
@@ -9,10 +9,17 @@ import SwiftUI
 
 public enum Layout {
     public enum Spacing {
+        /// xLarge: 64
         public static let xLarge: CGFloat = 64
+        /// large: 32
         public static let large: CGFloat = 32
+        /// medium: 24
+        public static let medium: CGFloat = 24
+        /// standard: 16
         public static let standard: CGFloat = 16
+        /// small: 8
         public static let small: CGFloat = 8
+        /// xSmall: 4
         public static let xSmall: CGFloat = 4
     }
 }

--- a/Sources/NiceComponents/Theme/NiceText.swift
+++ b/Sources/NiceComponents/Theme/NiceText.swift
@@ -1,0 +1,36 @@
+//
+//  NiceText.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-06-09.
+//
+
+import SwiftUI
+
+public protocol NiceText: View {
+
+    var text: NSAttributedString { get }
+    var style: TypeStyle { get }
+    static var defaultStyle: TypeStyle { get }
+
+    init(_ text: String, style: TypeStyle?)
+
+    init(_ text: NSAttributedString, style: TypeStyle?)
+
+    init(_ text: String, color: Color)
+}
+
+public extension NiceText {
+
+    init(_ text: String, style: TypeStyle? = nil) {
+        self.init(NSAttributedString(string: text), style: style)
+    }
+
+    init(_ text: String, color: Color) {
+        self.init(
+            NSAttributedString(string: text),
+            style: Self.defaultStyle.with(color: color)
+        )
+    }
+}
+

--- a/Sources/NiceComponents/Theme/TypeStyle.swift
+++ b/Sources/NiceComponents/Theme/TypeStyle.swift
@@ -20,3 +20,9 @@ public struct TypeStyle {
         self.lineLimit = lineLimit
     }
 }
+
+public extension TypeStyle {
+    func with(color: Color) -> TypeStyle {
+        TypeStyle(color: color, theme: self.theme)
+    }
+}

--- a/Sources/NiceComponents/Title/ItemTitle.swift
+++ b/Sources/NiceComponents/Title/ItemTitle.swift
@@ -7,13 +7,18 @@
 
 import SwiftUI
 
-public struct ItemTitle: View {
-    public let text: String
+public struct ItemTitle: NiceText {
+
+    public let text: NSAttributedString
     public let style: TypeStyle
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    static public var defaultStyle: TypeStyle {
+        Config.current.itemTitleStyle
+    }
+
+    public init(_ text: NSAttributedString, style: TypeStyle? = nil) {
         self.text = text
-        self.style = style ?? Config.current.itemTitleStyle
+        self.style = style ?? Self.defaultStyle
     }
 
     public var body: some View {
@@ -27,6 +32,18 @@ public struct ItemTitle: View {
 
 struct ItemTitle_Previews: PreviewProvider {
     static var previews: some View {
-        ItemTitle("Item Title")
+        VStack(spacing: Layout.Spacing.large) {
+            ItemTitle("Item Title")
+            ItemTitle("Item Title", color: .red)
+            ItemTitle(
+                NSAttributedString(
+                    string: "Item Title",
+                    attributes: [
+                        .underlineStyle: 1,
+                        .foregroundColor: Color.blue
+                    ]
+                )
+            )
+        }
     }
 }

--- a/Sources/NiceComponents/Title/ScreenTitle.swift
+++ b/Sources/NiceComponents/Title/ScreenTitle.swift
@@ -7,13 +7,18 @@
 
 import SwiftUI
 
-public struct ScreenTitle: View {
-    public let text: String
+public struct ScreenTitle: NiceText {
+
+    public let text: NSAttributedString
     public let style: TypeStyle
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public static var defaultStyle: TypeStyle {
+        Config.current.screenTitleStyle
+    }
+
+    public init(_ text: NSAttributedString, style: TypeStyle? = nil) {
         self.text = text
-        self.style = style ?? Config.current.screenTitleStyle
+        self.style = style ?? Self.defaultStyle
     }
 
     public var body: some View {

--- a/Sources/NiceComponents/Title/SectionTitle.swift
+++ b/Sources/NiceComponents/Title/SectionTitle.swift
@@ -7,13 +7,18 @@
 
 import SwiftUI
 
-public struct SectionTitle: View {
-    public let text: String
+public struct SectionTitle: NiceText {
+
+    public var text: NSAttributedString
     public let style: TypeStyle
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public static var defaultStyle: TypeStyle {
+        Config.current.sectionTitleStyle
+    }
+
+    public init(_ text: NSAttributedString, style: TypeStyle? = nil) {
         self.text = text
-        self.style = style ?? Config.current.sectionTitleStyle
+        self.style = style ?? Self.defaultStyle
     }
 
     public var body: some View {


### PR DESCRIPTION
### FOR #18 #19 #17 #13 #21 #16 #12 

All Text components now conform to `NiceText` which is a public protocol that allows for Text views to be initialized with an NSAttributedString. I also added a convenience init for passing only a color property to Text components as that was annoyingly complicated to do before. 

There's a new `shadowStyle` in Config which can be used with the `.shadow` modifier. 

Other improvements: 
- Layout documentation
- ContentLoadState is now equatable
- ResizableImage take in bundle string or URL 
- InactiveButton removed onClick modifier

![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 11 00 49](https://user-images.githubusercontent.com/17748596/172921971-8118a04e-507d-4e04-a44e-ee6c1025ccb1.png)

