### PR TITLE
add support for left and right aligned buttons

### DIFF
--- a/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
@@ -63,6 +63,10 @@ struct CustomizingComponentsView: View {
 
                     NiceButton("Over here as well", style: .secondary, rightImage: NiceButtonImage(systemIcon: "heart"), horizontalContentPadding: 20) {}
 
+                    NiceButton("Leading aligned", style: .primary, contentHorizontalAlignment: .leading) {}
+
+                    NiceButton(".. and trailing aligned", style: .secondary, contentHorizontalAlignment: .trailing) {}
+
 
                     NiceButton("and buttons with images", style: .primary, balanceImages: false) {}
                         .withLeftImage(

--- a/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
@@ -67,7 +67,6 @@ struct CustomizingComponentsView: View {
 
                     NiceButton(".. and trailing aligned", style: .secondary, contentHorizontalAlignment: .trailing) {}
 
-
                     NiceButton("and buttons with images", style: .primary, balanceImages: false) {}
                         .withLeftImage(
                             NiceImage(systemIcon: "fireworks", width: 25, height: 25),

--- a/Sources/NiceComponents/Button/NiceButton.swift
+++ b/Sources/NiceComponents/Button/NiceButton.swift
@@ -16,9 +16,13 @@ public struct NiceButton: View {
     /// The style configuration for the button.
     let style: NiceButtonStyle
 
-    /// Padding between the button text/images and edges of the button. Default is 8.
+    /// Padding between the button text/images and edges of the button.
+    /// Default is nil, unless contentHorizontalAlignment has been set, in which case it is 16.
     /// Set this to `nil` to have the button fill it's available space, like you'd set `maxWidth: .infinity`.
     var horizontalContentPadding: CGFloat?
+
+    /// When set, aligns the content of the button, including images inside the button. Default is `center`.
+    var contentHorizontalAlignment: TextAlignment
 
     /// An optional image to display on the left side of the button.
     var leftImage: NiceButtonImage?
@@ -42,15 +46,18 @@ public struct NiceButton: View {
     ///   - style: The style configuration for the button.
     ///   - inactive: A Boolean value that determines whether the button is inactive. Defaults to `false`.
     ///   - balanceImages: A Boolean value indicating whether the images should be balanced. Defaults to `true`.
+    ///   - contentHorizontalAlignment: Optionally align all content within the button. Defaults to `center`.
     ///   - leftImage: An optional image to display on the left side of the button.
     ///   - rightImage: An optional image to display on the right side of the button.
-    ///   - horizontalContentPadding: Padding between the button content and edges of the button. Default is nil, causing the button to expand to fill all available space.
+    ///   - horizontalContentPadding: Padding between the button content and edges of the button.
+    ///       Default is nil, unless contentHorizontalAlignment has been set, in which case it is 16.
     ///   - action: The closure to execute when the button is tapped.
     public init(
         _ text: String,
         style: NiceButtonStyle,
         inactive: Bool = false,
         balanceImages: Bool = true,
+        contentHorizontalAlignment: TextAlignment? = nil,
         leftImage: NiceButtonImage? = nil,
         rightImage: NiceButtonImage? = nil,
         horizontalContentPadding: CGFloat? = nil,
@@ -60,9 +67,10 @@ public struct NiceButton: View {
         self.style = style
         self.inactive = inactive
         self.balanceImages = balanceImages
+        self.contentHorizontalAlignment = contentHorizontalAlignment ?? .center
         self.leftImage = leftImage
         self.rightImage = rightImage
-        self.horizontalContentPadding = horizontalContentPadding
+        self.horizontalContentPadding = horizontalContentPadding ?? (contentHorizontalAlignment == nil ? nil : 16)
         self.action = action
     }
 
@@ -73,6 +81,10 @@ public struct NiceButton: View {
     public var body: some View {
         Button(action: action) {
            HStack(spacing: 0) {
+               if contentHorizontalAlignment == .trailing {
+                   Spacer()
+               }
+
                if let leftImage = leftImage {
                    leftImage.image
                        .padding(.leading, leftImage.offset)
@@ -91,6 +103,10 @@ public struct NiceButton: View {
                if let rightImage = rightImage {
                    rightImage.image
                        .padding(.trailing, rightImage.offset)
+               }
+
+               if contentHorizontalAlignment == .leading {
+                   Spacer()
                }
            }
            .frame(maxWidth: horizontalContentPadding == nil ? .infinity : nil)


### PR DESCRIPTION
This has come up a couple times where I've wanted a button that fills its parent view but has the text left aligned, but we don't really have a good way of supporting it. 

This PR adds that option by introducing a new `contentHorizontalAlignment` parameter that defaults to center but allows users to set it to trailing or leading to move the content to the respective edge.
It also slighly changes the default behaviour for the `horizontalContentPadding` parameter to fit with this. Since the default was previously nil in all cases, but if you set leading/trailing alignment that would mean the text is right up against the edge of the button which looks obviously wrong.

<img width="426" height="151" alt="Screenshot 2026-02-13 at 11 46 51 AM" src="https://github.com/user-attachments/assets/451f9ff0-159f-4f02-9f42-d2eda64c53de" />
